### PR TITLE
Make KSM Key optional

### DIFF
--- a/smtp-credentials.yaml
+++ b/smtp-credentials.yaml
@@ -12,23 +12,28 @@ Parameters:
     MinValue: 1
   KmsKeyArn:
     Type: String
+    Default: ''
     Description: ARN of the KMS key used to encrypt the SMTP credentials in Parameter Store
+
+Conditions:
+  KmsKeyProvided:
+    !Not [!Equals [!Ref 'KmsKeyArn', '']]
 
 Resources:
   SmtpUserGroup:
     Type: AWS::IAM::Group
     Properties:
-      GroupName: SMTPUserGroup
+      GroupName: !Sub SMTPUserGroup-${AWS::StackName}
   SmtpUser:
     Type: AWS::IAM::User
     Properties:
-      UserName: SMTPUser
+      UserName: !Sub SMTPUser-${AWS::StackName}
       Groups:
         - !Ref SmtpUserGroup
   SmtpUserPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: SMTPUserPolicy
+      PolicyName: !Sub SMTPUserPolicy-${AWS::StackName}
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -61,7 +66,7 @@ Resources:
   SmtpLambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: SMTPLambdaExecutionRole
+      RoleName: !Sub SMTPLambdaExecutionRole-${AWS::StackName}
       Description: Role assumed by Lambda to generate SMTP credentials
       AssumeRolePolicyDocument: 
         Version: 2012-10-17
@@ -80,36 +85,32 @@ Resources:
                   Action:
                     - logs:CreateLogStream
                     - logs:PutLogEvents
-                  Resource:
-                    - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/SMTPCredentialsLambdaFunction"
-                    - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/SMTPCredentialsLambdaFunction:log-stream:*"
-                - Effect: Allow
-                  Action:
-                    - kms:Decrypt
-                    - kms:DescribeKey
-                    - kms:CreateGrant
-                    - kms:Encrypt
-                  Resource:
-                    - !Ref KmsKeyArn
+                    - logs:CreateLogGroup
+                  Resource: arn:aws:logs:*:*:*
+                - !If 
+                  - KmsKeyProvided
+                  - Effect: Allow
+                    Action:
+                      - kms:Decrypt
+                      - kms:DescribeKey
+                      - kms:CreateGrant
+                      - kms:Encrypt
+                    Resource:
+                      - !Ref KmsKeyArn
+                  - !Ref AWS::NoValue
                 - Effect: Allow
                   Action:
                     - ssm:PutParameter
                     - ssm:DeleteParameter
                   Resource:
-                    - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-username"
-                    - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-password"
-
-  SmtpLambdaLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Join [ "/", [/aws, lambda, SMTPCredentialsLambdaFunction]]
+                    - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-username-${AWS::StackName}"
+                    - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-password-${AWS::StackName}"
 
   SmtpLambdaFunction:
     Type: AWS::Lambda::Function
-    DependsOn: SmtpLambdaLogGroup
     Properties:
       Description: Generates SMTP credentials and stores in Parameter Store
-      FunctionName: SMTPCredentialsLambdaFunction
+      FunctionName: !Sub SMTPCredentialsLambdaFunction-${AWS::StackName}
       Handler: index.lambda_handler
       MemorySize: 128
       Environment:
@@ -179,33 +180,43 @@ Resources:
 
           def put_parameter(value,type):
             try:
-              ssm.put_parameter(
-                        Name='smtp-'+type,
+              if os.environ['KMS_KEY_ARN']:
+                ssm.put_parameter(
+                          Name='smtp-' + type + '-${AWS::StackName}',
+                          Description='SMTP '+type+' for email communications',
+                          Value=value,
+                          Type='SecureString',
+                          KeyId=os.environ['KMS_KEY_ARN'],
+                          Overwrite=True,
+                          Tier='Standard'
+                      )
+              else:
+                ssm.put_parameter(
+                        Name='smtp-' + type + '-${AWS::StackName}',
                         Description='SMTP '+type+' for email communications',
                         Value=value,
                         Type='SecureString',
-                        KeyId=os.environ['KMS_KEY_ARN'],
                         Overwrite=True,
                         Tier='Standard'
                     )
               return True
             except Exception as e:
-              print("Error putting parameter smtp-"+type+": "+str(e))
+              print("Error putting parameter smtp-"+type+"-${AWS::StackName}: "+str(e))
               return False
 
           def delete_smtp_credentials(type):
             try:
-              ssm.delete_parameter(Name='smtp-'+type)
+              ssm.delete_parameter(Name='smtp-'+type+'-${AWS::StackName}')
               return True
             except Exception as e:
-              print("Error deleting parameter smtp-"+type+": "+str(e))
+              print("Error deleting parameter smtp-"+type+"-${AWS::StackName}: "+str(e))
               return False
 
 
           def lambda_handler(event, context):
             log.debug('%s', event)
             parameter_type = event['ResourceProperties']['ParameterType']
-            parameter_arn = "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-"+parameter_type
+            parameter_arn = "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/smtp-"+parameter_type+"-${AWS::StackName}"
             key = event['ResourceProperties']['Key']
             proceed = "True"
 


### PR DESCRIPTION
KMS Key can now supplied optionally.
If you do not specify a KMS Key the default key is used.

Fixes along the way:
- Prepended Stackname to Resource names. If not done like this and using explicit names, deployment of multiple stack instances of the template fails
- Changed logging behaviour of custom resource Lambda function so that log group is no longer created in deleted by the stack (which makes debugging impossible in case of deployment failures).